### PR TITLE
Drop inline-block from ul.pageColumns a (fix #143)

### DIFF
--- a/public/styles/index.styl
+++ b/public/styles/index.styl
@@ -220,7 +220,6 @@ ul.pageColumns
     column-break-inside avoid
 
   a
-    display inline-block
     text-decoration none
     font-weight 600
     &:hover


### PR DESCRIPTION
It appears that chrome will move the doc links only when they are set to `display: inline-block`, while removing `display: inline-block` altogether fixes this and doesn't change behavior in other browsers.
